### PR TITLE
Added histology and death at n years variable

### DIFF
--- a/v6-sessions/v6-sessions/sql/sarcoma_features.sql
+++ b/v6-sessions/v6-sessions/sql/sarcoma_features.sql
@@ -77,6 +77,22 @@ WITH
         FROM 
             death
     ),
+    --- histology group
+    histo_group AS (
+    	SELECT
+	    	primary_tumor.person_id, 
+	    	CASE
+                WHEN primary_tumor.diagnosis_concept IN (36529541,36532543,36540557,36547895,36550930,36565259,36716490,44500609,44501363,44502347,44502555) THEN '1004 Well-differentiated liposarcoma'
+                WHEN primary_tumor.diagnosis_concept IN (36529541,36532543,36540557,36547895,36550930,36565259,36716490,44500609,44501363,44502347,44502555) THEN '1007 Dedifferentiated liposarcoma'
+                WHEN primary_tumor.diagnosis_concept IN (36517959,36519685,36527462,36528858,36542197,36548944,36567690,36717566,44500548) THEN '1010 Leiomyosarcoma'
+                WHEN primary_tumor.diagnosis_concept IN (36564558,44500681) THEN '1013 Solitary fibrous tumour'
+                WHEN primary_tumor.diagnosis_concept IN (36518164,36539077,36542266,36545198,36564186,36565777,36567910,36567978) THEN '1016 MPNST'
+                WHEN primary_tumor.diagnosis_concept IN (36517265,36536317,36539821,36557573,36563675,36717542,44500743,44501448,44501970,44502968,44505249) THEN '1019 UPS'
+                WHEN primary_tumor.diagnosis_concept IN (36517688,36520993,36521675,36521767,36522306,36522587,36523615,36523729,36526673,36527934,36528528,36528553,36529241,36529898,36529914,36530213,36530702,36532061,36533385,36534511,36534836,36535692,36536209,36536483,36538083,36539258,36539942,36540600,36542848,36543361,36543793,36544017,36544331,36544801,36545011,36545492,36548018,36548485,36550322,36553275,36553366,36553716,36554396,36555105,36555193,36555344,36556092,36556544,36557446,36557554,36559526,36559764,36560560,36560902,36561436,36561836,36561934,36562510,36562642,36562881,36563318,36563461,36563534,36565276,36566540,36567178,42511689,42512026,42512136,42512235,42512243,42512454,42512487,42512587,42512696,42512826,42512845,42512942,44499454,44500553,44500656,44500745,44500820,44501225,44501226,44501367,44501368,44502560,44502563) THEN '1022 Other sarcomas'
+                ELSE 'N/A'
+	        END AS histology
+	    FROM primary_tumor
+    ),
     --- get main surgery information
     surgery AS (
         SELECT
@@ -501,7 +517,7 @@ SELECT
         WHEN person.age > 70 and person.age <= 80 THEN '71-80'
 	    WHEN person.age > 80 THEN '>80'
         ELSE 'N/A'
-    END as Age_Group, -- change with the actual age groups
+    END as Age_Group,
     ISNULL(person.sex, 'N/A') as Sex,
     death.censor as Censor,
     death.status as patient_status,
@@ -517,6 +533,7 @@ SELECT
     survival.survival_9yr,
     survival.survival_10yr,
     ISNULL(primary_tumor.diagnosis, 'N/A') as Primary_diagnosis,
+    histo_group.histology as histology,
     CAST(IIF(surgery.surgery_concept IS NOT NULL, 1, 0) AS BIT) AS surgery_yn,
     ISNULL(surgery.surgery, 'N/A') as Surgery,
     CAST(IIF(tumor_rupture.measurement_concept_id IS NOT NULL, 1, 0) AS BIT) AS tumor_rupture,
@@ -542,6 +559,9 @@ LEFT JOIN
 LEFT JOIN
     survival
     ON person.person_id = survival.person_id
+LEFT JOIN
+    histo_group
+    ON person.person_id = histo_group.person_id
 LEFT JOIN
     surgery
     ON person.person_id = surgery.person_id


### PR DESCRIPTION
Added histology variable with 6 groups:

- 1004/1007 Liposarcoma (after a discussion with Paolo we agreed to merge this two cohorts)
- 1010 Leiomyosarcoma
- 1013 Solitary fibrous tumour
- 1016 MPNST
- 1019 UPS
- 1022 Other sarcomas

In addition, I had a call with Paolo this morning and he asked me to add also a death at 1,2,3.. years variable (the inverse of the survival ones: 0 if the patient is alive at n yrs, 1 if the patient is dead or censored). The new variables are:

- death_1yr
- death_2yr
- death_3yr
- death_4yr
- death_5yr
- death_6yr
- death_7yr
- death_8yr
- death_9yr
- death_10yr